### PR TITLE
Address Feedback QA migration

### DIFF
--- a/new-arch-migration/EMBEDDED.md
+++ b/new-arch-migration/EMBEDDED.md
@@ -10,7 +10,7 @@ GitGuardian provides a set of scripts that require specific tools to be installe
 
 You need to be an administrator of the GitGuardian namespace where the application is deployed.
 
-Please ensure you have the latest legacy version installed before upgrading to the new architecture.
+⚠️ Please ensure you have the latest legacy version installed before upgrading to the new architecture.
 
 ⚠️ The GitGuardian team needs to update your license information (Channel switching from `prod` to `stable`) to give you access to the new architecture, so you need to [sync with them](?subject=Migration+New+Architecture+in+place+migration+external) before upgrading.
 
@@ -105,7 +105,7 @@ Please ensure you have the latest legacy version installed before upgrading to t
 
         • There are currently 1 updates available in the Admin Console, ensuring latest is deployed
 
-        • To access the Admin Console, run kubectl kots admin-console --namespace <gitguardian_namespace>
+        • To access the Admin Console, run kubectl kots admin-console --namespace default
 
         • Currently deployed release: sequence <N>, version YYYY.MM.PATCH
         • Downloading available release: sequence <N>, version YYYY.MM.PATCH
@@ -145,7 +145,7 @@ If you encounter issues after migration, you can rollback to the legacy architec
 
     ```bash
     ./scale.sh \
-        --namespace <gitguardian_namespace> \
+        --namespace default \
         --component hook \
         --component internal-api \
         --component internal-api-long \
@@ -163,7 +163,7 @@ If you encounter issues after migration, you can rollback to the legacy architec
 2. Verify all workers are idle:
 
     ```bash
-    ./inspect-workers.sh --namespace <gitguardian_namespace>
+    ./inspect-workers.sh --namespace default
     ```
 
     **Expected result:**
@@ -176,7 +176,7 @@ If you encounter issues after migration, you can rollback to the legacy architec
 3. Backup the GitGuardian PostgreSQL database:
 
     ```bash
-    ./backup-db.sh --namespace <gitguardian_namespace> \
+    ./backup-db.sh --namespace default \
         -o pg-dump-gitguardian-v2-$(date +'%Y%m%d_%H%M%S').gz
     ```
 

--- a/new-arch-migration/README.md
+++ b/new-arch-migration/README.md
@@ -29,7 +29,7 @@ GitGuardian provides a set of scripts that require specific tools to be installe
 
 You need to be an administrator of the GitGuardian namespace where the application is deployed.
 
-Please ensure you have the latest legacy version installed before upgrading to the new architecture.
+⚠️ Please ensure you have the latest legacy version installed before upgrading to the new architecture.
 
 ⚠️ The GitGuardian team needs to update your license information (Channel switching from `prod` to `stable`) to give you access to the new architecture, so you need to [sync with them](?subject=Migration+New+Architecture+in+place+migration+external) before upgrading.
 

--- a/new-arch-migration/README.md
+++ b/new-arch-migration/README.md
@@ -52,7 +52,7 @@ You need to be an administrator of the GitGuardian namespace where the applicati
     If needed, specify the Kubernetes namespace with `--namespace` (default namespace is used if not specified).
 
 3. You can now migrate GitGuardian to the new architecture using the following command line:
-        
+
     ```bash
     # For Online installation
     ./migrate.sh --namespace <gitguardian_namespace> \
@@ -68,7 +68,7 @@ You need to be an administrator of the GitGuardian namespace where the applicati
 
     ```bash
     => Migrate GitGuardian application
-        • Checking for application updates ✓  
+        • Checking for application updates ✓
 
         • There are currently 1 updates available in the Admin Console, ensuring latest is deployed
 
@@ -79,8 +79,10 @@ You need to be an administrator of the GitGuardian namespace where the applicati
         • Deploying release: sequence <N>, version YYYY.MM.PATCH
     OK
     ```
-    
+
 Et voilà! You should access to your GitGuardian dashboard.
+
+ℹ️ Please note that a new Ingress/LoadBalancer resource will be created during the migration and will replace the old one, so you will need to manually update any DNS CNAME record pointing to that resource after the migration.
 
 ### Rollback procedure
 
@@ -125,7 +127,7 @@ release "redis" uninstalled
 OK
 
 => Migrate GitGuardian application
-    • Checking for application updates ✓  
+    • Checking for application updates ✓
 
     • There are currently 1 updates available in the Admin Console, ensuring latest is deployed
 
@@ -188,26 +190,26 @@ At the end of the deployment, depending on how you expose the application (Ingre
 
     => Install V2 application
       • Deploying Admin Console
-        • Creating namespace ✓  
-        • Waiting for datastore to be ready ✓  
-      • Waiting for Admin Console to be ready ✓  
-      • Waiting for installation to complete ✓  
+        • Creating namespace ✓
+        • Waiting for datastore to be ready ✓
+      • Waiting for Admin Console to be ready ✓
+      • Waiting for installation to complete ✓
     OK
     ```
 
 2. Once you are ready to switch the traffic to the new application:
 
     Scale down the legacy application
-        
+
     ```yaml
-    ./scale.sh --namespace <v1_namespace> \ 
+    ./scale.sh --namespace <v1_namespace> \
       --v1 \
       --all \
       --replicas 0
     ```
-        
+
     *Expected result:*
-        
+
     ```yaml
     => Retrieve GitGuardian deployments
     OK
@@ -239,9 +241,9 @@ At the end of the deployment, depending on how you expose the application (Ingre
     => Scale deployment.apps/gitguardian-app to 0 replicas
     OK
     ```
-    
+
 3. Update the new application hostname and deploy the new configuration using this command:
-        
+
     ```yaml
     ./update-config.sh --namespace <new_namespace> \
         --set "app_hostname=<app_hostname>" \


### PR DESCRIPTION
1. Add warning in the prerequisites regarding the version to be on
2. Replace `<gitguardian_namespace>` with `default` for embedded cluster