### PR TITLE
Fix GitLab source sync

### DIFF
--- a/team-mapping-gitlab-gitguardian/README.md
+++ b/team-mapping-gitlab-gitguardian/README.md
@@ -38,11 +38,11 @@ Optional environment variables:
 - `GITGUARDIAN_INSTANCE` - The URL of a self-hosted GitGuardian instance. Just the scheme and hostname: https://gitguardian.example.com
 - `SEND_EMAIL` - Defines whether we should send an email to users when sending invitations
 - `REMOVE_MEMBERS` - Defines whether we should delete users from teams if they are not in any Gitlab group
-- `EXCLUDE_ADMIN` - Defines whether we should exclude admin users from sync
 - `DEFAULT_INCIDENT_PERMISSION` - Defines the default incident permission level for team members, defaults to `can_edit`, it's value must be one of :
   - `can_view` : For read permissions
   - `can_edit` : For read and write permissions
   - `full_access` : For manager permissions
+- `INVITE_DOMAINS`: A comma-separated list of domains to match when inviting users to the platform.
 
 In order to ensure you have the correct configuration, you can run the following command to display the configuration:
 

--- a/team-mapping-gitlab-gitguardian/config.py
+++ b/team-mapping-gitlab-gitguardian/config.py
@@ -38,12 +38,10 @@ class Config:
             logger_level = getattr(logging, logger_level_name.upper())
 
         invite_domains = {
-            s.strip() for s in os.environ.get("INVITE_DOMAINS", "").split(",")
+            domain.strip()
+            for domain in os.environ.get("INVITE_DOMAINS", "").split(",")
+            if len(domain.strip())
         }
-        try:
-            invite_domains.remove("")
-        except KeyError:
-            pass
 
         return cls(
             gitlab_token=os.environ["GITLAB_ACCESS_TOKEN"],

--- a/team-mapping-gitlab-gitguardian/gitguardian_client.py
+++ b/team-mapping-gitlab-gitguardian/gitguardian_client.py
@@ -204,8 +204,8 @@ def send_invitation(
     Send an invitation to join a workspace, the invitation is sent to member_email
     """
 
-    _, _, rhs = member_email.partition("@")
-    if CONFIG.invite_domains and rhs not in CONFIG.invite_domains:
+    domain = member_email.rsplit("@", 1)[-1]
+    if CONFIG.invite_domains and domain not in CONFIG.invite_domains:
         logger.info("Email doesn't match invite domains: %s", member_email)
         return None
 

--- a/team-mapping-gitlab-gitguardian/gitlab_client.py
+++ b/team-mapping-gitlab-gitguardian/gitlab_client.py
@@ -1,0 +1,156 @@
+import requests
+
+from config import CONFIG
+from util import (
+    GitlabProject,
+    GitlabUserGroup,
+    transform_gitlab_project,
+    transform_gitlab_user,
+)
+
+GITLAB_USER_GRAPHQL_QUERY = """
+query ($cursor: String) {
+    users(first: 100, after: $cursor, humans: true) {
+        pageInfo {
+            endCursor
+        }
+        nodes {
+            name
+            emails {
+                nodes {
+                    email
+                }
+            }
+            groups {
+                nodes {
+                    id
+                    name
+                    fullName
+                    fullPath
+                }
+            }
+        }
+    }
+}
+"""
+
+GITLAB_PROJECT_GRAPHQL_QUERY = """
+query ($cursor: String) {
+    projects(after: $cursor, first: 100) {
+        pageInfo {
+            endCursor
+        }
+        nodes {
+            id
+            name
+            fullPath
+            group {
+                id
+                name
+                fullName
+                fullPath
+            }
+        }
+    }
+}
+"""
+
+
+def fetch_gitlab_users() -> list[GitlabUserGroup]:
+    """
+    Fetch all Gitlab users and their groups using GraphQL, iterate on pagination if needed
+    """
+
+    users = []
+
+    url = f"{CONFIG.gitlab_url}/api/graphql"
+    headers = {"Authorization": f"Bearer {CONFIG.gitlab_token}"}
+
+    default_variables: dict[str, str] = {}
+    response = requests.post(
+        url=url,
+        json={"query": GITLAB_USER_GRAPHQL_QUERY, "variables": default_variables},
+        headers=headers,
+        timeout=60,
+    )
+    response.raise_for_status()
+
+    data = response.json()
+    end_cursor = data["data"]["users"]["pageInfo"]["endCursor"]
+    users.extend(
+        [transform_gitlab_user(user) for user in data["data"]["users"]["nodes"]]
+    )
+
+    while end_cursor:
+        response = requests.post(
+            url=f"{CONFIG.gitlab_url}/api/graphql",
+            json={
+                "query": GITLAB_USER_GRAPHQL_QUERY,
+                "variables": {"cursor": end_cursor, **default_variables},
+            },
+            headers=headers,
+            timeout=60,
+        )
+        response.raise_for_status()
+
+        data = response.json()
+        end_cursor = data["data"]["users"]["pageInfo"]["endCursor"]
+        users.extend(
+            [transform_gitlab_user(user) for user in data["data"]["users"]["nodes"]]
+        )
+
+    return users
+
+
+def fetch_gitlab_projects() -> list[GitlabProject]:
+    """
+    Fetch all gitlab projects and their groups using GraphQL, iterate on pagination if needed
+    """
+
+    projects: list[GitlabProject] = []
+
+    url = f"{CONFIG.gitlab_url}/api/graphql"
+    headers = {"Authorization": f"Bearer {CONFIG.gitlab_token}"}
+
+    default_variables: dict[str, str] = {}
+    response = requests.post(
+        url=url,
+        json={"query": GITLAB_PROJECT_GRAPHQL_QUERY, "variables": default_variables},
+        headers=headers,
+        timeout=60,
+    )
+    response.raise_for_status()
+
+    data = response.json()
+    end_cursor = data["data"]["projects"]["pageInfo"]["endCursor"]
+    projects.extend(
+        [
+            transform_gitlab_project(project)
+            for project in data["data"]["projects"]["nodes"]
+            if project["group"] is not None
+        ]
+    )
+
+    while end_cursor:
+        response = requests.post(
+            url=url,
+            json={
+                "query": GITLAB_PROJECT_GRAPHQL_QUERY,
+                "variables": {"cursor": end_cursor, **default_variables},
+            },
+            headers=headers,
+            timeout=60,
+        )
+        response.raise_for_status()
+
+        data = response.json()
+        end_cursor = data["data"]["projects"]["pageInfo"]["endCursor"]
+        projects.extend(
+            [
+                transform_gitlab_project(project)
+                for project in data["data"]["projects"]["nodes"]
+                if project["group"] is not None
+            ]
+        )
+
+    return projects

--- a/team-mapping-gitlab-gitguardian/sync_gitlab.py
+++ b/team-mapping-gitlab-gitguardian/sync_gitlab.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from collections import defaultdict
 from typing import Iterable
@@ -244,8 +243,6 @@ def synchronize_sources(
             + "\n - ".join(unmonitored_projects)
         )
 
-    logger.debug("gitlab_projects_per_group: %s", json.dumps(gitlab_projects_per_group))
-
     def diff_sources(
         team: Team,
         gitlab_id: str,
@@ -271,8 +268,6 @@ def synchronize_sources(
     for team in gg_teams:
         if gitlab_id := team_gitlab_id(team):
             team_projects = gitlab_projects_per_group.get(gitlab_id, None)
-            logger.debug("Team: %r (%s)", team, gitlab_id)
-            logger.debug("Team projects: %r", team_projects)
             if team_projects is None:
                 logger.debug(
                     "No match for team: %d - %s (%s)",
@@ -320,7 +315,6 @@ def create_team_from_group(group: GitlabGroup) -> Team:
     """
     Given a Gitlab group, create the corresponding GitGuardian team
     """
-    logger.debug("create_team_from_group: %s", json.dumps(group))
     payload = CreateTeam(
         group["fullName"],
         description=team_description_from_group(group),
@@ -386,7 +380,6 @@ def synchronize_teams(
         if group_id not in teams_to_remove
     }
 
-    logger.debug("Team intersection: %s", json.dumps(list(team_intersection)))
     for team in team_intersection:
         gg_team = teams_by_external_id[team]
         group = groups_by_id[team]

--- a/team-mapping-gitlab-gitguardian/util.py
+++ b/team-mapping-gitlab-gitguardian/util.py
@@ -1,0 +1,104 @@
+import json
+import logging
+from typing import Iterable, TypedDict
+
+from email_validator import EmailNotValidError, validate_email
+from pygitguardian.models import Team
+
+logger = logging.getLogger(__name__)
+
+GitlabUserGroup = TypedDict(
+    "GitlabUserGroup",
+    {
+        "name": str,
+        "email": str | None,
+        "groups": list[dict[str, str]],
+    },
+)
+GitlabUser = TypedDict(
+    "GitlabUser",
+    {
+        "name": str,
+        "email": str | None,
+    },
+)
+GitlabGroup = TypedDict(
+    "GitlabGroup",
+    {
+        "id": str,
+        "fullName": str,
+        "fullPath": str,
+        "users": list[GitlabUser],
+    },
+)
+GitlabProject = TypedDict(
+    "GitlabProject",
+    {
+        "name": str,
+        "group": str,
+        "fullPath": str,
+        "id": str,
+    },
+)
+
+
+def team_description_from_group(group: GitlabGroup) -> str:
+    keys_to_keep = {"id", "fullPath"}
+    return json.dumps(
+        {key: value for key, value in group.items() if key in keys_to_keep}
+    )
+
+
+def team_gitlab_id(team: Team) -> str | None:
+    if team.description:
+        try:
+            metadata = json.loads(team.description)
+            if "id" in metadata:
+                return metadata["id"]
+        except json.JSONDecodeError:
+            pass
+    return None
+
+
+def transform_gitlab_user(gitlab_user: dict) -> GitlabUserGroup:
+    """
+    Transform the GraphQL representation of a User to a simpler dictionary
+    """
+
+    groups = gitlab_user.get("groups", {}).get("nodes", [])
+    for group in groups:
+        group["fullPath"] = " / ".join(group["fullPath"].split("/"))
+
+    return {
+        "name": gitlab_user["name"],
+        "email": get_valid_email(e["email"] for e in gitlab_user["emails"]["nodes"]),
+        "groups": groups,
+    }
+
+
+def transform_gitlab_project(gitlab_project: dict) -> GitlabProject:
+    group = gitlab_project["group"] or {"id": None}
+    full_path = " / ".join(gitlab_project["fullPath"].split("/"))
+    return {
+        "id": gitlab_project["id"].split("/")[-1],
+        "name": gitlab_project["name"],
+        "fullPath": full_path,
+        "group": group["id"],
+    }
+
+
+def get_valid_email(emails: Iterable[str]) -> str | None:
+    """
+    Get the first valid email address from a list of potential email addresses.
+    """
+    for email in emails:
+        try:
+            emailinfo = validate_email(email, check_deliverability=False)
+            return emailinfo.normalized
+        except EmailNotValidError as e:
+            logger.debug(
+                "Email validation failed - email: %s, error: %s",
+                email,
+                str(e),
+            )
+    return None

--- a/team-mapping-gitlab-gitguardian/util.py
+++ b/team-mapping-gitlab-gitguardian/util.py
@@ -34,10 +34,10 @@ GitlabGroup = TypedDict(
 GitlabProject = TypedDict(
     "GitlabProject",
     {
-        "name": str,
-        "group": str,
-        "fullPath": str,
         "id": str,
+        "name": str,
+        "fullPath": str,
+        "group": str | None,
     },
 )
 


### PR DESCRIPTION
A user of the script reported that some GitGuardian teams were missing monitored sources after running the script. Our original matching was case-sensitive and using different values (the GitLab name vs path) so some sources were missed. 

This PR updates the matching to use the GitLab ID as well as renaming teams to use the GitLab `fullName` (as shown in the GitLab UI) instead of the GitLab `fullPath`. It also removes the `EXCLUDE_ADMIN` configuration option as it doesn't work to exclude GitLab admins.